### PR TITLE
Improve logger forwarding

### DIFF
--- a/src/Writer/LoggerWriter.php
+++ b/src/Writer/LoggerWriter.php
@@ -6,6 +6,9 @@ namespace Knotlog\Writer;
 
 use Knotlog\Log;
 use Psr\Log\LoggerInterface;
+use Stringable;
+
+use function is_string;
 
 final readonly class LoggerWriter implements LogWriter
 {
@@ -21,9 +24,37 @@ final readonly class LoggerWriter implements LogWriter
         $context = $log->all();
 
         if ($log->hasError()) {
-            $this->logger->error('{' . $this->errorKey . '}', $context);
+            $this->logger->error($this->getError($context), $context);
         } else {
-            $this->logger->info('{' . $this->messageKey . '}', $context);
+            $this->logger->info($this->getInfo($context), $context);
         }
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function getError(array $context): string|Stringable
+    {
+        $message = $context[$this->errorKey] ?? null;
+
+        if (is_string($message) || $message instanceof Stringable) {
+            return $message;
+        }
+
+        return 'Knotlog error';
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function getInfo(array $context): string|Stringable
+    {
+        $message = $context[$this->messageKey] ?? null;
+
+        if (is_string($message) || $message instanceof Stringable) {
+            return $message;
+        }
+
+        return 'Knotlog entry';
     }
 }

--- a/tests/Writer/LoggerWriterTest.php
+++ b/tests/Writer/LoggerWriterTest.php
@@ -25,7 +25,7 @@ final class LoggerWriterTest extends TestCase
 
         $logger->expects($this->once())
             ->method('info')
-            ->with('{message}', ['message' => 'test', 'user_id' => 123]);
+            ->with('test', ['message' => 'test', 'user_id' => 123]);
 
         $logger->expects($this->never())
             ->method('error');
@@ -45,7 +45,7 @@ final class LoggerWriterTest extends TestCase
 
         $logger->expects($this->once())
             ->method('error')
-            ->with('{error}', ['error' => 'Something went wrong', 'user_id' => 123]);
+            ->with('Something went wrong', ['error' => 'Something went wrong', 'user_id' => 123]);
 
         $logger->expects($this->never())
             ->method('info');
@@ -65,7 +65,7 @@ final class LoggerWriterTest extends TestCase
 
         $logger->expects($this->once())
             ->method('error')
-            ->with('{error}', ['exception' => 'RuntimeException', 'user_id' => 123]);
+            ->with('Knotlog error', ['exception' => 'RuntimeException', 'user_id' => 123]);
 
         $logger->expects($this->never())
             ->method('info');
@@ -85,7 +85,7 @@ final class LoggerWriterTest extends TestCase
 
         $logger->expects($this->once())
             ->method('info')
-            ->with('{msg}', ['msg' => 'custom message', 'user_id' => 123]);
+            ->with('custom message', ['msg' => 'custom message', 'user_id' => 123]);
 
         $writer = new LoggerWriter($logger, messageKey: 'msg');
         $writer->write($log);
@@ -102,7 +102,7 @@ final class LoggerWriterTest extends TestCase
 
         $logger->expects($this->once())
             ->method('error')
-            ->with('{err}', ['error' => 'Something went wrong', 'err' => 'custom error']);
+            ->with('custom error', ['error' => 'Something went wrong', 'err' => 'custom error']);
 
         $writer = new LoggerWriter($logger, errorKey: 'err');
         $writer->write($log);
@@ -128,7 +128,7 @@ final class LoggerWriterTest extends TestCase
 
         $logger->expects($this->once())
             ->method('info')
-            ->with('{message}', $expectedContext);
+            ->with('Knotlog entry', $expectedContext);
 
         $writer = new LoggerWriter($logger);
         $writer->write($log);


### PR DESCRIPTION
Rather than assuming message or error key exist and can be used as strings, capture them directly from context, with default fallback.